### PR TITLE
feat: lua51 constraint

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 68ff3dc2cc97969f7385679da7c9ff96738aa9cc275fa6bab77316eb3340ea8e
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -22,6 +22,9 @@ requirements:
       then: make
   run_exports: 
     - ${{ pin_subpackage(name) }}
+  run_constraints: 
+    # Luajit should not be installed together with lua 5.1
+    - lua <5.1|>=5.2
 
 tests:
   - package_contents:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This adds a constraint so that luajit is not installed together with lua 5.1.*.